### PR TITLE
Fix get_model Deprecation warning in Django 1.8

### DIFF
--- a/taggit_templatetags2/compat.py
+++ b/taggit_templatetags2/compat.py
@@ -1,0 +1,9 @@
+import django
+
+if django.VERSION < (1, 7):
+    from django.db.models import loading
+    get_model = loading.get_model
+
+else:
+    from django.apps import apps
+    get_model = apps.get_model

--- a/taggit_templatetags2/settings.py
+++ b/taggit_templatetags2/settings.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.db.models.loading import get_model
+from taggit_templatetags2.compat import get_model
 
 # define the minimal weight of a tag in the tagcloud
 TAGCLOUD_MIN = getattr(settings, 'TAGGIT_TAGCLOUD_MIN', 1.0)

--- a/taggit_templatetags2/templatetags/taggit_templatetags2_tags.py
+++ b/taggit_templatetags2/templatetags/taggit_templatetags2_tags.py
@@ -1,6 +1,5 @@
 from django import template
 from django.db.models import Count
-from django.db.models.loading import get_model
 from django.core.exceptions import FieldError
 
 from classytags.core import Options
@@ -8,6 +7,7 @@ from classytags.arguments import Argument
 from classytags.helpers import AsTag
 
 from taggit_templatetags2 import settings
+from taggit_templatetags2.compat import get_model
 
 T_MAX = getattr(settings, 'TAGCLOUD_MAX', 6.0)
 T_MIN = getattr(settings, 'TAGCLOUD_MIN', 1.0)


### PR DESCRIPTION
Now it should work with Django 1.9
