### PR TITLE
Ability for pk to be named something other than `id`

### DIFF
--- a/taggit_templatetags2/templatetags/taggit_templatetags2_tags.py
+++ b/taggit_templatetags2/templatetags/taggit_templatetags2_tags.py
@@ -127,7 +127,7 @@ class GetTagForObject(AsTag):
                 taggit_taggeditem_items__content_type=content_type)
         except:
             tags = tag_model.objects.filter(
-                taggit_taggeditem_items__object_id=source_object.id,
+                taggit_taggeditem_items__object_id=source_object.pk,
                 taggit_taggeditem_items__content_type=content_type)
 
         if varname:


### PR DESCRIPTION
Removes an instance which causes an error if the model name primary key name is not `id`
